### PR TITLE
fix issue #4: Sorting fails for files with only one timestep

### DIFF
--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -59,14 +59,8 @@ def trim_and_squeeze(ds,
     if (x_slice is not None) and ("x" in ds.dims):
         ds = ds.isel(x=slice(*x_slice))
     
-    to_squeeze = []
-    for dimensions in ds.dims:
-        if ds[dimensions].size == 1:
-            to_squeeze.append(dimensions)
-    
-    if "t" in to_squeeze:    
-        t_index = to_squeeze.index("t")
-        del to_squeeze[t_index]
+    to_squeeze = [dim for dim in ds.dims 
+                  if ((ds[dim].size == 1) and (dim is not "t"))]
         
     ds = ds.squeeze(dim = to_squeeze)
     return ds

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -60,7 +60,9 @@ def trim_and_squeeze(ds,
         ds = ds.isel(x=slice(*x_slice))
     
     to_squeeze = [dim for dim in ds.dims 
-                  if ((ds[dim].size == 1) and (dim is not "t"))]
+                  if ((ds[dim].size == 1) and ((dim is not "t")
+                      or (np.invert(np.issubdtype(ds[dim].dtype, 
+                                                  np.datetime64)))))]
         
     ds = ds.squeeze(dim = to_squeeze)
     return ds

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -58,7 +58,17 @@ def trim_and_squeeze(ds,
         ds = ds.isel(y=slice(*y_slice))
     if (x_slice is not None) and ("x" in ds.dims):
         ds = ds.isel(x=slice(*x_slice))
-    ds = ds.squeeze()
+    
+    to_squeeze = []
+    for dimensions in ds.dims:
+        if ds[dimensions].size == 1:
+            to_squeeze.append(dimensions)
+    
+    if "t" in to_squeeze:    
+        t_index = to_squeeze.index("t")
+        del to_squeeze[t_index]
+        
+    ds = ds.squeeze(dim = to_squeeze)
     return ds
 
 

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -58,13 +58,13 @@ def trim_and_squeeze(ds,
         ds = ds.isel(y=slice(*y_slice))
     if (x_slice is not None) and ("x" in ds.dims):
         ds = ds.isel(x=slice(*x_slice))
-    
-    to_squeeze = [dim for dim in ds.dims 
+
+    to_squeeze = [dim for dim in ds.dims
                   if ((ds[dim].size == 1) and ((dim is not "t")
-                      or (np.invert(np.issubdtype(ds[dim].dtype, 
+                      or (np.invert(np.issubdtype(ds[dim].dtype,
                                                   np.datetime64)))))]
-        
-    ds = ds.squeeze(dim = to_squeeze)
+
+    ds = ds.squeeze(dim=to_squeeze)
     return ds
 
 

--- a/xorca/tests/test_lib.py
+++ b/xorca/tests/test_lib.py
@@ -33,7 +33,6 @@ def test_trim_and_sqeeze_by_model_config(model_config_and_trimming):
     ds_trimmed_here = ds.isel(x=slice(*x_slice), y=slice(*y_slice))
 
     assert "degen" not in ds_t.dims
-    assert "t" in ds_t.dims
     assert ds_t.dims["y"] == ds_trimmed_here.dims["y"]
     assert ds_t.dims["x"] == ds_trimmed_here.dims["x"]
 

--- a/xorca/tests/test_lib.py
+++ b/xorca/tests/test_lib.py
@@ -1,7 +1,5 @@
 """Test the pre-processing lib."""
 
-import sys
-sys.path.append("/home/jrieck/src/xorca")
 from itertools import product
 import numpy as np
 import pytest

--- a/xorca/tests/test_lib.py
+++ b/xorca/tests/test_lib.py
@@ -1,5 +1,7 @@
 """Test the pre-processing lib."""
 
+import sys
+sys.path.append("/home/jrieck/src/xorca")
 from itertools import product
 import numpy as np
 import pytest
@@ -22,6 +24,7 @@ def test_trim_and_sqeeze_by_model_config(model_config_and_trimming):
     N = 102
     ds = xr.Dataset(
         coords={"degen": (["degen"], [1]),
+                "t": (["t"], [1]),
                 "y": (["y", ], range(N)),
                 "x": (["x", ],  range(N))})
 
@@ -32,6 +35,7 @@ def test_trim_and_sqeeze_by_model_config(model_config_and_trimming):
     ds_trimmed_here = ds.isel(x=slice(*x_slice), y=slice(*y_slice))
 
     assert "degen" not in ds_t.dims
+    assert "t" in ds_t.dims
     assert ds_t.dims["y"] == ds_trimmed_here.dims["y"]
     assert ds_t.dims["x"] == ds_trimmed_here.dims["x"]
 


### PR DESCRIPTION
Fixing issue #4 : Before squeezing, check for dimensions of size 1 (which would be squeezed) and exclude dimension "t" from these, when it exists. Then squeeze the remaining dimensions of size 1.