### PR TITLE
Do not squeeze depth dim

### DIFF
--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -75,13 +75,6 @@ def trim_and_squeeze(ds,
                       not _is_time_dim(ds, dim) and
                       not _is_z_dim(ds, dim))]
 
-    to_squeeze = [dim for dim in ds.dims
-                  if ((ds[dim].size == 1)
-                      and ((dim is not "t") or
-                           np.invert(np.issubdtype(ds[dim].dtype,
-                                                   np.datetime64)))
-                      and (dim not in orca_names.z_dims))]
-
     ds = ds.squeeze(dim=to_squeeze)
     return ds
 

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -60,8 +60,8 @@ def trim_and_squeeze(ds,
         ds = ds.isel(x=slice(*x_slice))
 
     to_squeeze = [dim for dim in ds.dims
-                  if ((ds[dim].size == 1) 
-                      and ((dim is not "t") or 
+                  if ((ds[dim].size == 1)
+                      and ((dim is not "t") or
                            np.invert(np.issubdtype(ds[dim].dtype,
                                                    np.datetime64)))
                       and (dim not in orca_names.z_dims))]

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -47,8 +47,6 @@ def trim_and_squeeze(ds,
         "NEST": {},
     }
 
-    z_dims = ["z_c", "z_l", "z"]
-
     yx_slice_dict = how_to_trim.get(
         model_config, {})
     if y_slice is None:
@@ -65,7 +63,7 @@ def trim_and_squeeze(ds,
                   if (((ds[dim].size == 1) and ((dim is not "t")
                       or (np.invert(np.issubdtype(ds[dim].dtype,
                                                   np.datetime64)))))
-                      and (dim not in z_dims))]
+                      and (dim not in orca_names.z_dims)]
 
     ds = ds.squeeze(dim=to_squeeze)
     return ds

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -60,10 +60,11 @@ def trim_and_squeeze(ds,
         ds = ds.isel(x=slice(*x_slice))
 
     to_squeeze = [dim for dim in ds.dims
-                  if (((ds[dim].size == 1) and ((dim is not "t")
-                      or (np.invert(np.issubdtype(ds[dim].dtype,
-                                                  np.datetime64)))))
-                      and (dim not in orca_names.z_dims)]
+                  if ((ds[dim].size == 1) 
+                      and ((dim is not "t") or 
+                           np.invert(np.issubdtype(ds[dim].dtype,
+                                                   np.datetime64)))
+                      and (dim not in orca_names.z_dims))]
 
     ds = ds.squeeze(dim=to_squeeze)
     return ds

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -46,6 +46,8 @@ def trim_and_squeeze(ds,
         "GLOBAL": {"y": (1, -1), "x": (1, -1)},
         "NEST": {},
     }
+    
+    z_dims = ['z_c', 'z_l']
 
     yx_slice_dict = how_to_trim.get(
         model_config, {})
@@ -62,7 +64,8 @@ def trim_and_squeeze(ds,
     to_squeeze = [dim for dim in ds.dims
                   if ((ds[dim].size == 1) and ((dim is not "t")
                       or (np.invert(np.issubdtype(ds[dim].dtype,
-                                                  np.datetime64)))))]
+                                                  np.datetime64))))
+                      and (dim not in z_dims))]
 
     ds = ds.squeeze(dim=to_squeeze)
     return ds

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -46,7 +46,7 @@ def trim_and_squeeze(ds,
         "GLOBAL": {"y": (1, -1), "x": (1, -1)},
         "NEST": {},
     }
-    
+
     z_dims = ["z_c", "z_l", "z"]
 
     yx_slice_dict = how_to_trim.get(
@@ -62,10 +62,10 @@ def trim_and_squeeze(ds,
         ds = ds.isel(x=slice(*x_slice))
 
     to_squeeze = [dim for dim in ds.dims
-                  if ((ds[dim].size == 1) and ((dim is not "t")
+                  if (((ds[dim].size == 1) and ((dim is not "t")
                       or (np.invert(np.issubdtype(ds[dim].dtype,
                                                   np.datetime64)))))
-                      and (dim not in z_dims)]
+                      and (dim not in z_dims))]
 
     ds = ds.squeeze(dim=to_squeeze)
     return ds

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -60,7 +60,7 @@ def trim_and_squeeze(ds,
         ds = ds.isel(x=slice(*x_slice))
 
     def _is_singleton(ds, dim):
-        return (ds[dim] == 1)
+        return (ds[dim].size == 1)
 
     def _is_time_dim(ds, dim):
         return (dim in orca_names.t_dims or

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -71,7 +71,7 @@ def trim_and_squeeze(ds,
         return (dim in orca_names.z_dims)
 
     to_squeeze = [dim for dim in ds.dims
-                  if (is_singleton(ds, dim) and
+                  if (_is_singleton(ds, dim) and
                       not _is_time_dim(ds, dim) and
                       not _is_z_dim(ds, dim))]
 

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -59,12 +59,21 @@ def trim_and_squeeze(ds,
     if (x_slice is not None) and ("x" in ds.dims):
         ds = ds.isel(x=slice(*x_slice))
 
+    def _is_singleton(ds, dim):
+        return (ds[dim] == 1)
+
+    def _is_time_dim(ds, dim):
+        return (dim in orca_names.t_dims or
+                np.invert(np.issubdtype(ds[dim].dtype,
+                                        np.datetime64)))
+
+    def _is_z_dim(ds, dim):
+        return (dim in orca_names.z_dims)
+
     to_squeeze = [dim for dim in ds.dims
-                  if ((ds[dim].size == 1)
-                      and ((dim is not "t") or
-                           np.invert(np.issubdtype(ds[dim].dtype,
-                                                   np.datetime64)))
-                      and (dim not in orca_names.z_dims))]
+                  if (not _is_singleton(ds, dim) and
+                      not _is_time_dim(ds, dim) and
+                      not _is_z_dim(ds, dim))]
 
     ds = ds.squeeze(dim=to_squeeze)
     return ds

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -64,16 +64,23 @@ def trim_and_squeeze(ds,
 
     def _is_time_dim(ds, dim):
         return (dim in orca_names.t_dims or
-                np.invert(np.issubdtype(ds[dim].dtype,
-                                        np.datetime64)))
+                np.issubdtype(ds[dim].dtype,
+                              np.datetime64))
 
     def _is_z_dim(ds, dim):
         return (dim in orca_names.z_dims)
 
     to_squeeze = [dim for dim in ds.dims
-                  if (not _is_singleton(ds, dim) and
+                  if (is_singleton(ds, dim) and
                       not _is_time_dim(ds, dim) and
                       not _is_z_dim(ds, dim))]
+
+    to_squeeze = [dim for dim in ds.dims
+                  if ((ds[dim].size == 1)
+                      and ((dim is not "t") or
+                           np.invert(np.issubdtype(ds[dim].dtype,
+                                                   np.datetime64)))
+                      and (dim not in orca_names.z_dims))]
 
     ds = ds.squeeze(dim=to_squeeze)
     return ds

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -47,7 +47,7 @@ def trim_and_squeeze(ds,
         "NEST": {},
     }
     
-    z_dims = ['z_c', 'z_l']
+    z_dims = ["z_c", "z_l", "z"]
 
     yx_slice_dict = how_to_trim.get(
         model_config, {})
@@ -64,8 +64,8 @@ def trim_and_squeeze(ds,
     to_squeeze = [dim for dim in ds.dims
                   if ((ds[dim].size == 1) and ((dim is not "t")
                       or (np.invert(np.issubdtype(ds[dim].dtype,
-                                                  np.datetime64))))
-                      and (dim not in z_dims))]
+                                                  np.datetime64)))))
+                      and (dim not in z_dims)]
 
     ds = ds.squeeze(dim=to_squeeze)
     return ds
@@ -380,8 +380,7 @@ def load_xorca_dataset(data_files=None, aux_files=None, decode_cf=True,
     for af, ac in zip(aux_files, _aux_files_chunks):
         aux_ds.update(
             rename_dims(xr.open_dataset(af, decode_cf=False,
-                                        chunks=ac)).squeeze())
-
+                                        chunks=ac)))
     # Again, we first have to open all data sets to filter the input chunks.
     _data_files_chunks = map(
         lambda df: get_all_compatible_chunk_sizes(

--- a/xorca/lib.py
+++ b/xorca/lib.py
@@ -63,7 +63,7 @@ def trim_and_squeeze(ds,
         return (ds[dim].size == 1)
 
     def _is_time_dim(ds, dim):
-        return (dim in orca_names.t_dims or
+        return (dim in orca_names.t_dims and
                 np.issubdtype(ds[dim].dtype,
                               np.datetime64))
 

--- a/xorca/orca_names.py
+++ b/xorca/orca_names.py
@@ -108,3 +108,8 @@ z_dims = (
     "depthv",
     "depthw"
 )
+
+t_dims = (
+    "t",
+    "time_counter"
+)

--- a/xorca/orca_names.py
+++ b/xorca/orca_names.py
@@ -100,11 +100,11 @@ rename_dims = {
 }
 
 z_dims = (
-    "z_c", 
-    "z_l", 
-    "z", 
-    "deptht", 
-    "depthu", 
-    "depthv", 
+    "z_c",
+    "z_l",
+    "z",
+    "deptht",
+    "depthu",
+    "depthv",
     "depthw"
 )

--- a/xorca/orca_names.py
+++ b/xorca/orca_names.py
@@ -98,3 +98,13 @@ rename_dims = {
     "Y": "y",
     "X": "x"
 }
+
+z_dims = (
+    "z_c", 
+    "z_l", 
+    "z", 
+    "deptht", 
+    "depthu", 
+    "depthv", 
+    "depthw"
+)

--- a/xorca/tests/test_lib.py
+++ b/xorca/tests/test_lib.py
@@ -23,6 +23,8 @@ def test_trim_and_sqeeze_by_model_config(model_config_and_trimming):
     ds = xr.Dataset(
         coords={"degen": (["degen"], [1]),
                 "t": (["t"], [np.datetime64('1970-01-01')]),
+                "z_c": (["z_c"], [1]),
+                "z_l": (["z_l"], [1]),
                 "y": (["y", ], range(N)),
                 "x": (["x", ],  range(N))})
 
@@ -34,6 +36,8 @@ def test_trim_and_sqeeze_by_model_config(model_config_and_trimming):
 
     assert "degen" not in ds_t.dims
     assert "t" in ds_t.dims
+    assert "z_c" in ds_t.dims
+    assert "z_l" in ds_t.dims
     assert ds_t.dims["y"] == ds_trimmed_here.dims["y"]
     assert ds_t.dims["x"] == ds_trimmed_here.dims["x"]
 
@@ -45,6 +49,8 @@ def test_trim_and_sqeeze_by_yx_slice(y_slice, x_slice):
     ds = xr.Dataset(
         coords={"degen": (["degen"], [1]),
                 "t": (["t"], [np.datetime64('1970-01-01')]),
+                "z_c": (["z_c"], [1]),
+                "z_l": (["z_l"], [1]),
                 "y": (["y", ], range(N)),
                 "x": (["x", ],  range(N))})
 
@@ -63,6 +69,8 @@ def test_trim_and_sqeeze_by_yx_slice(y_slice, x_slice):
 
     assert "degen" not in ds_t.dims
     assert "t" in ds_t.dims
+    assert "z_c" in ds_t.dims
+    assert "z_l" in ds_t.dims
     assert ds_t.dims["y"] == ds_trimmed_here.dims["y"]
     assert ds_t.dims["x"] == ds_trimmed_here.dims["x"]
 


### PR DESCRIPTION
#12 : I included `z_c`, `z_l` and `z` in the dimensions not to squeeze in `trim_and_squeeze()`. I also had to remove a `.squeeze()` in `load_xorca_dataset` (l 383) because that basically made `trim_and_squeeze()` ineffective for aux_files. I am not sure whether it has other effects...